### PR TITLE
#5 feat/news issues loader impl

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ webdriver_manager==4.0.1
 
 python-dotenv~=1.0.1
 requests~=2.32.2
+beautifulsoup4~=4.12.3

--- a/src/news/news_issue_loader.py
+++ b/src/news/news_issue_loader.py
@@ -1,9 +1,32 @@
+from abc import ABC
+
 from src.base import IssueLoader
+from src.news.target_platform_list import target_news_platform_list
 
 
-class NewsIssueLoader(IssueLoader):
+class NewsIssueLoader(IssueLoader, ABC):
 
     def __init__(self):
         super().__init__()
         self.target_platforms = target_news_platform_list
         self.main_platform = 'News'
+
+    def _get_news_items(self, elem):
+        return elem.select('ul.press_ranking_list > li.as_thumb')
+
+    def _get_news_rank(self, elem):
+        return elem.select_one('em.list_ranking_num').get_text()
+
+    def _get_news_title(self, elem):
+        return elem.select_one('strong.list_title').get_text(strip=True)
+
+    def _get_news_link(self, elem):
+        return elem.select_one('a')['href']
+
+    def _get_news_views(self, elem):
+        news_view = None
+        if elem.select_one('span.list_view'):
+            news_view = int(elem.select_one('span.list_view')
+                            .get_text(strip=True).replace(',', '')
+                            .replace('조회수', ''))
+        return news_view

--- a/src/news/news_issue_loader.py
+++ b/src/news/news_issue_loader.py
@@ -1,0 +1,9 @@
+from src.base import IssueLoader
+
+
+class NewsIssueLoader(IssueLoader):
+
+    def __init__(self):
+        super().__init__()
+        self.target_platforms = target_news_platform_list
+        self.main_platform = 'News'

--- a/src/news/news_issue_loader.py
+++ b/src/news/news_issue_loader.py
@@ -1,4 +1,7 @@
+import traceback
 from abc import ABC
+
+from bs4 import BeautifulSoup
 
 from src.base import IssueLoader
 from src.news.target_platform_list import target_news_platform_list
@@ -30,3 +33,25 @@ class NewsIssueLoader(IssueLoader, ABC):
                             .get_text(strip=True).replace(',', '')
                             .replace('조회수', ''))
         return news_view
+
+    def _parse(self, html):
+        try:
+            soup = BeautifulSoup(html, 'html.parser')
+            news_items = []
+
+            ranking_box = soup.select('div.press_ranking_home > div.press_ranking_box')
+
+            for sub_ranking in ranking_box:
+                items = self._get_news_items(sub_ranking)
+                for item in items:
+                    news_items.append({
+                        "순위": self._get_news_rank(item),
+                        "제목": self._get_news_title(item),
+                        "URL": self._get_news_link(item),
+                        "조회수": self._get_news_views(item),
+                    })
+
+            return news_items
+        except Exception as e:
+            traceback.print_exc()
+            return []

--- a/src/news/target_platform_list.py
+++ b/src/news/target_platform_list.py
@@ -1,0 +1,12 @@
+target_news_platform_list = {
+        "뉴시스": "https://media.naver.com/press/003/ranking",
+        "연합뉴스": "https://media.naver.com/press/001/ranking",
+        "매일경제": "https://media.naver.com/press/009/ranking",
+        "한국경제": "https://media.naver.com/press/215/ranking",
+        "머니투데이": "https://media.naver.com/press/008/ranking",
+        "뉴스1": "https://media.naver.com/press/421/ranking",
+        "중앙일보": "https://media.naver.com/press/025/ranking",
+        "이데일리": "https://media.naver.com/press/018/ranking",
+        "헤럴드경제": "https://media.naver.com/press/016/ranking",
+        "서울신문": "https://media.naver.com/press/081/ranking"
+    }


### PR DESCRIPTION
## 🌁 배경
close #5 
* IssueLoader 클래스를 상속받아 뉴스 플랫폼의 이슈 데이터를 로드하고 파싱하는 NewsIssueLoader 클래스를 구현합니다. 이 클래스는 특정 뉴스 플랫폼에서 이슈 데이터를 크롤링하고, 데이터를 파싱하여 반환하는 기능을 포함합니다.

## ✅ 수정 내역
 * IssueLoader 클래스를 상속받는 NewsIssueLoader 클래스 생성
 * 초기화 메서드 구현 (__init__)
 * HTML을 파싱하여 뉴스 데이터를 추출하는 _parse 메서드 구현
 * BeautifulSoup을 사용하여 HTML 파싱
 * 뉴스 항목을 순회하며 데이터 추출
 * 추출된 데이터 리스트를 반환
 * 예외 처리 및 에러 로그 기록


## 📕 리뷰 노트
* 각 뉴스 항목 추출 메서드는 HTML 요소를 탐색하여 필요한 데이터를 가져옵니다.
* 예외 발생 시 전체 스택 트레이스를 출력하고 빈 리스트를 반환하도록 설정합니다.