### PR TITLE
#9 Task Producer 구현

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ webdriver_manager==4.0.1
 python-dotenv~=1.0.1
 requests~=2.32.2
 beautifulsoup4~=4.12.3
+pika~=1.3.2

--- a/src/file_manager/__init__.py
+++ b/src/file_manager/__init__.py
@@ -1,0 +1,1 @@
+from .file_manager import FileManager

--- a/src/news/__init__.py
+++ b/src/news/__init__.py
@@ -1,0 +1,4 @@
+from .news_comments_crawler import NewsCommentsCrawler
+from .news_content_crawler import NewsContentCrawler
+from .news_issue_loader import NewsIssueLoader
+from .target_platform_list import target_news_platform_list

--- a/src/parallel_processing/producer.py
+++ b/src/parallel_processing/producer.py
@@ -1,6 +1,17 @@
+import datetime
+import logging
+
 import pika
 import json
 import os
+
+from src.file_manager import FileManager
+from src.news.news_issue_loader import NewsIssueLoader
+
+logger = logging.getLogger(__name__)
+job_logger = logging.getLogger('job_logger')
+
+file_manger = FileManager()
 
 
 def send_task(task, queue):
@@ -18,3 +29,17 @@ def send_task(task, queue):
             delivery_mode=2,  # 메시지를 지속적으로 저장
         ))
     connection.close()
+
+
+def run_producer():
+    main_types = ['News']
+
+    for main_type in main_types:
+        job_logger.info(f"[Start {main_type} Crawling] Starting {main_type} Crawling on {datetime.datetime.now()}")
+
+        if main_type == 'News':
+            news_issue_loader = NewsIssueLoader()
+            issues = news_issue_loader.crawl_issues()
+            job_logger.info(issues)
+            for issue in issues:
+                send_task(issue, 'content_queue')

--- a/src/parallel_processing/producer.py
+++ b/src/parallel_processing/producer.py
@@ -1,0 +1,20 @@
+import pika
+import json
+import os
+
+
+def send_task(task, queue):
+    connection = pika.BlockingConnection(pika.ConnectionParameters(os.getenv('RABBITMQ_URL'), 5672))
+    channel = connection.channel()
+
+    channel.queue_declare(queue=queue, durable=True)
+
+    message = json.dumps(task)
+    channel.basic_publish(
+        exchange='',
+        routing_key=queue,
+        body=message.encode('utf-8'),
+        properties=pika.BasicProperties(
+            delivery_mode=2,  # 메시지를 지속적으로 저장
+        ))
+    connection.close()


### PR DESCRIPTION
## 🌁 배경
close #9 
* run_producer 함수를 구현하여 RabbitMQ를 사용해 크롤링 작업을 수행하고, 크롤링된 데이터를 처리합니다.

## ✅ 수정 내역
* RabbitMQ 연결 설정
* 채널 생성 및 큐 선언 
* 메시지 전송
* 작업(task)을 JSON으로 직렬화하여 메시지 생성
* channel.basic_publish를 사용하여 메시지를 큐에 전송
* 메시지가 지속적으로 저장되도록 설정
* NewsIssueLoader를 사용하여 뉴스 이슈 크롤링
* crawl_issues 메서드를 호출하여 뉴스 이슈 데이터를 가져옴
* 크롤링된 이슈 데이터를 로깅
* 각 이슈를 RabbitMQ 큐에 전송
* send_task 함수를 호출하여 이슈 데이터를 content_queue에 전송

## 📕 리뷰 노트
* RabbitMQ URL은 환경 변수 RABBITMQ_URL에서 가져옵니다.
* 크롤링된 뉴스 이슈 데이터는 NewsIssueLoader를 사용하여 가져옵니다.