### PR TITLE
#26 Docker Compose Script 작성

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '3'
+services:
+  selenium-grid-driver:
+    image: selenium/standalone-chrome:latest
+    platform: linux/amd64
+    container_name: selenium-grid-driver
+    ports:
+      - "4444:4444"
+      - "7900:7900"
+    shm_size: "2g"
+    environment:
+      - START_XVFB=false
+      - SE_NODE_OVERRIDE_MAX_SESSIONS=true
+      - SE_NODE_MAX_SESSIONS=10
+    networks:
+      - crawling-app-network
+
+  rabbitmq:
+    image: rabbitmq:3-management-alpine
+    container_name: rabbitmq
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    environment:
+      AMQP_URL: 'amqp://rabbitmq?connection_attempts=5&retry_delay=5'
+      RABBITMQ_DEFAULT_USER: "guest"
+      RABBITMQ_DEFAULT_PASS: "guest"
+
+    networks:
+      - crawling-app-network
+
+  crawling-app:
+    image: jeongseho1/issuer-crawling-app:latest
+    container_name: crawling-app
+    depends_on:
+      - selenium-grid-driver
+      - rabbitmq
+    volumes:
+      - /issuer/crawling_data:/crawling_data
+    networks:
+      - crawling-app-network
+
+networks:
+  crawling-app-network:
+    driver: bridge


### PR DESCRIPTION
## 🌁 배경
* Docker Container간 통신을 위해 Docker Compose Script를 작성합니다. 해당 스크립트에는 rabbitmq와 selenium-grid 설정이 포함되어 있어야 합니다.

## ✅ 수정 내역
* Docker Compose 배포 작성

## 📕 리뷰 노트