### PR TITLE
#30 파일 저장 오류 수정 (Ubuntu 환경 대응)

### DIFF
--- a/src/file_manager/file_manager.py
+++ b/src/file_manager/file_manager.py
@@ -16,7 +16,7 @@ class FileManager:
         if not data:
             return
 
-        current_datetime = datetime.now().strftime("%Y-%m-%d_%H:00:00")
+        current_datetime = datetime.now().strftime("%Y-%m-%d_%H-00-00")
         base_dir = os.getenv('DIR_CRAWLING_DATA')
         if not os.path.exists(f'{base_dir}/{current_datetime}/{main_type}'):
             os.makedirs(f'{base_dir}/{current_datetime}/{main_type}')


### PR DESCRIPTION
## 🌁 배경
close #30 
Ubunut 에서 ':' 문자는 파일 이름에 사용이 불가능합니다. 파일 이름을 재 지정하여 정상 작동하도록 수정합니다.

## ✅ 수정 내역
* FileManger에서 파일 이름 지정 로직 수정

## 📕 리뷰 노트